### PR TITLE
Added mention of an issue some users had when using filebrowser with docker for the first time

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -46,5 +46,4 @@ docker run \
     filebrowser/filebrowser
 ```
 
-By default, we already have a [configuration file with some defaults](https://github.com/filebrowser/filebrowser/blob/master/.docker.json) so you can just mount the root and the database. Although you can overwrite by mounting a directory to with a new config file.
-
+By default, we already have a [configuration file with some defaults](https://github.com/filebrowser/filebrowser/blob/master/.docker.json) so you can just mount the root and the database. Although you can overwrite by mounting a directory to with a new config file. If you don't already have a database file, make sure to create a new empty file under the path you specified. Otherwise, Docker will create an empty folder instead of an empty file, resulting in an error when mounting the database into the container.


### PR DESCRIPTION
I just recently started using filebrowser and immediately ran into a problem when trying to run it for the first time. A quick google-search revealed that others faced the issue as well (e.g. filebrowser/filebrowser#667), which is why I would suggest to add a short sentence to the docs to keep new users from running into the same problem. It's basically about docker creating an empty folders by default and crashing when trying to mount a file into a folder.

I'm not a native English speaker and would love to hear any suggestions to improve wording or grammar.

Thank you very much to all contributors for developing, maintaining and documenting great open-source software.