### PR TITLE
Fix the docker run command in installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -50,7 +50,7 @@ docker run \
     -v /path/to/root:/srv \
     -v /path/filebrowser.db:/database.db \
     -v /path/.filebrowser.json:/.filebrowser.json \
-    --user $(id -u):$(id -g)
+    --user $(id -u):$(id -g) \
     -p 80:80 \
     filebrowser/filebrowser
 ```


### PR DESCRIPTION
A backslash is missing in the docker run command