### PR TITLE
Fixing docker example command for latest alpine image

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -50,7 +50,7 @@ File Browser is also available as a Docker image. You can find it on [Docker Hub
 ```shell
 docker run \
     -v /path/to/root:/srv \
-    -v /path/filebrowser.db:/database.db \
+    -v /path/filebrowser.db:/database/filebrowser.db \
     -v /path/.filebrowser.json:/.filebrowser.json \
     -u $(id -u):$(id -g) \
     -p 8080:80 \


### PR DESCRIPTION
While checking out filebrowser, I just noticed the database file is in the latest version of the alpine image in the same location as for the non-alpine image.  
`/database/filebrowser.db`

This simply adjusts the example docker run command of the [install docs](https://filebrowser.org/installation#docker)