### PR TITLE
Add information on shell commands

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -8,3 +8,4 @@ Most of the configuration can be understood through our Command Line Interface d
 
 {% page-ref page="command-runner.md" %}
 
+{% page-ref page="shell-commands.md" %}

--- a/configuration/shell-commands.md
+++ b/configuration/shell-commands.md
@@ -9,3 +9,10 @@ To enable commands these need to either be done on a per-user basis (including f
 You can do this by adding them in Settings > User Management > (edit user) > Commands or to *apply to all new users created from that point forward* they can be set in Settings > Global Settings
 
 {% hint style="info" %} If using a proxy manager then remember to enable websockets support for the Filebrowser proxy{% endhint %}
+
+{% hint style="info" %} If using Docker and you want to add a new command that is not in the base image then you will need to build a custom Docker image using `filebrowser/filebrowser' as a base image.  For example to add 7z:
+``` 
+FROM filebrowser/filebrowser
+RUN sudo apt install p7zip-full
+```
+{% endhint %}

--- a/configuration/shell-commands.md
+++ b/configuration/shell-commands.md
@@ -1,0 +1,11 @@
+# Shell commands
+
+Within Filebrowser you can toggle the shell (`< >` icon at the top right) and this will open a shell command window at the bottom of the screen.
+
+**By default no commands are availabe as the command list is empty**
+
+To enable commands these need to either be done on a per-user basis (including for the Admin user).
+
+You can do this by adding them in Settings > User Management > (edit user) > Commands or to *apply to all new users created from that point forward* they can be set in Settings > Global Settings
+
+{% hint style="info" %} If using a proxy manager then remember to enable websockets support for the Filebrowser proxy{% endhint %}


### PR DESCRIPTION
After reading the helpful discussion in https://github.com/filebrowser/filebrowser/issues/1092 I thought it would be useful to add a page to the documentation explaining how to enable shell commands.