### PR TITLE
Documentation Fix - npm run watch to npm run dev

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -37,7 +37,7 @@ npm run build
 This will install the dependencies and build the frontend so you can then embed it into the Go app. Although, if you want to play with it, you'll get bored of building it after every change you do. So, you can run the command below to watch for changes:
 
 ```bash
-npm run watch
+npm run dev
 ```
 
 ### Backend


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/80836f9f-c4aa-4c55-a0ca-aecf2eb0042b)

npm run watch is the incorrect command. It does not work.

npm run dev launches the front end, and watches for changes.