### PR TITLE
Update installation.md to include multiple mounts and sample docker compose

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -70,6 +70,28 @@ docker run \
     filebrowser/filebrowser:s6
 ```
 {% endtab %}
+
+{% tab title="docker-compose.yaml" %}
+```yaml
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:s6
+    container_name: filebrowser
+    restart: unless-stopped
+    volumes:
+      - /path/to/root:/srv
+      - ./filebrowser:/database/
+      - ./filebrowser:/config/
+    environment:
+      - PUID=1000
+      - PGID=1000
+```
+{% endtab %}
+
 {% endtabs %}
 
 By default, we already have a [configuration file with some defaults](https://github.com/filebrowser/filebrowser/blob/master/docker/root/defaults/settings.json) so you can just mount the root and the database. Although you can overwrite by mounting a directory with a new config file. If you don't already have a database file, make sure to create a new empty file under the path you specified. Otherwise, Docker will create an empty folder instead of an empty file, resulting in an error when mounting the database into the container.
+
+**Need to mount more than 1 volume**? 
+ - Simply add another volume mount as a subdirectory in `/srv`
+ - For example: `-v /path/to/root:/srv` above now becomes `-v /path/to/root:/srv/root` and a new volume will be `-v /path/to/data:/srv/data`. Filebrowser will automatically display both of these folders on the home page.


### PR DESCRIPTION
Took awhile to figure out from https://www.reddit.com/r/selfhosted/comments/vxo7ga/filebrowser_multiple_directories/ and general searching. 

Decided to raise a PR for it. 

For the compose example, I used traefik, I had a bit more labels but not sure if repo owner wants to include traefik as example. 

Traefik with labels + watchtower for upgrades.

```
services:
  filebrowser:
    image: filebrowser/filebrowser:s6
    container_name: filebrowser
    restart: unless-stopped
    volumes:
      - /docs:/srv/docs
      - /my-photos-videos:/srv/my-photos-videos
      - ./filebrowser:/database/
      - ./filebrowser:/config/
    environment:
      - PUID=1000
      - PGID=1000
    networks:
      - web
    labels:
      - 'traefik.enable=true'
      - 'traefik.http.routers.filebrowser.rule=Host(`files.example.com`)'
      - 'traefik.http.routers.filebrowser.entrypoints=https'
      - 'traefik.http.routers.filebrowser.tls.certResolver=primary'
      - 'traefik.http.routers.filebrowser.service=filebrowser'
      - 'traefik.http.services.filebrowser.loadBalancer.server.port=80'
      - 'traefik.docker.network=web'
      - 'com.centurylinklabs.watchtower.enable=true'

# Connect to pre-defined network so other containers with docker-compose can be discovered by Traefik
networks:
  web:
    external: true
```

Thank you for this awesome OSS project! Best one I have tried for self hosting thus far.